### PR TITLE
Removing eval

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -12,7 +12,7 @@ supports other methods besides POST.
 * Appears to actually work. A good feature to have.
 * Encapsulates posting of file/binary parts and name/value parameter parts, similar to 
   most browsers' file upload forms.
-* Provides an UploadIO helper module to prepare IO objects for inclusion in the params
+* Provides an UploadIO helper class to prepare IO objects for inclusion in the params
   hash of the multipart post object.
 
 == SYNOPSIS:

--- a/test/net/http/post/test_multipart.rb
+++ b/test/net/http/post/test_multipart.rb
@@ -23,19 +23,19 @@ class Net::HTTP::Post::MultiPartTest < Test::Unit::TestCase
   def test_form_multipart_body
     File.open(TEMP_FILE, "w") {|f| f << "1234567890"}
     @io = File.open(TEMP_FILE)
-    UploadIO.convert! @io, "text/plain", TEMP_FILE, TEMP_FILE
+    @io = UploadIO.new @io, "text/plain", TEMP_FILE
     assert_results Net::HTTP::Post::Multipart.new("/foo/bar", :foo => 'bar', :file => @io)
   end
   def test_form_multipart_body_put
     File.open(TEMP_FILE, "w") {|f| f << "1234567890"}
     @io = File.open(TEMP_FILE)
-    UploadIO.convert! @io, "text/plain", TEMP_FILE, TEMP_FILE
+    @io = UploadIO.new @io, "text/plain", TEMP_FILE
     assert_results Net::HTTP::Put::Multipart.new("/foo/bar", :foo => 'bar', :file => @io)
   end
-  
+
   def test_form_multipart_body_with_stringio
     @io = StringIO.new("1234567890")
-    UploadIO.convert! @io, "text/plain", TEMP_FILE, TEMP_FILE
+    @io = UploadIO.new @io, "text/plain", TEMP_FILE
     assert_results Net::HTTP::Post::Multipart.new("/foo/bar", :foo => 'bar', :file => @io)
   end
 


### PR DESCRIPTION
This patch removes the instance_eval in UploadIO. It's a performance problem and can be handled easily by just wrapping the IO object. This patch does change the API by removing the UploadIO.convert! method but it's worth it.
