### PR TITLE
EOFError (bad content body) with special characters (maybe only on ruby 1.9.2)

### DIFF
--- a/lib/parts.rb
+++ b/lib/parts.rb
@@ -25,6 +25,7 @@ module Parts
     end
 
     def build_part(boundary, name, value)
+      value.force_encoding('BINARY') if value.respond_to?(:force_encoding)
       part = ''
       part << "--#{boundary}\r\n"
       part << "Content-Disposition: form-data; name=\"#{name.to_s}\"\r\n"


### PR DESCRIPTION
when I submit a query with a file and with another params which contains special characters (ie: éèîü etc ..) it breaks. 

EOFError (bad content body)

I don't know if it's the right way to fix it but it works !

Note: tested only on ruby 1.9.2
