### PR TITLE
fixing FilePart length calculation to include newlines

### DIFF
--- a/lib/parts.rb
+++ b/lib/parts.rb
@@ -40,8 +40,9 @@ module Parts
     def initialize(boundary, name, io)
       file_length = io.respond_to?(:length) ?  io.length : File.size(io.local_path)
       @head = build_head(boundary, name, io.original_filename, io.content_type, file_length)
-      @length = @head.length + file_length
-      @io = CompositeReadIO.new(StringIO.new(@head), io, StringIO.new("\r\n"))
+      @foot = "\r\n"
+      @length = @head.length + file_length + @foot.length
+      @io = CompositeReadIO.new(StringIO.new(@head), io, StringIO.new(@foot))
     end
 
     def build_head(boundary, name, filename, type, content_len)

--- a/test/test_parts.rb
+++ b/test/test_parts.rb
@@ -1,0 +1,23 @@
+require 'test/unit'
+
+require 'parts'
+require 'stringio'
+require 'composite_io'
+
+class FilePartTest < Test::Unit::TestCase
+  TEMP_FILE = "temp.txt"
+
+  def setup
+    File.open(TEMP_FILE, "w") {|f| f << "1234567890"}
+    io =  UploadIO.new(TEMP_FILE, "text/plain")
+    @part = Parts::FilePart.new("boundary", "afile", io)
+  end
+
+  def teardown
+    File.delete(TEMP_FILE) rescue nil
+  end
+
+  def test_correct_length
+    assert_equal @part.length, @part.to_io.read.length
+  end
+end


### PR DESCRIPTION
the FilePart length should include the "\r\n" in the length that gets added to the Composite IO or?

discovered this bug when trying to upload 2 files at the same time which resulted in a 500 error from the nginx server I was testing against.
