### PR TITLE
Better header specification for parts

### DIFF
--- a/lib/composite_io.rb
+++ b/lib/composite_io.rb
@@ -11,7 +11,7 @@
 #
 #     crio = CompositeReadIO.new(StringIO.new('one'), StringIO.new('two'), StringIO.new('three'))
 #     puts crio.read # => "onetwothree"
-#  
+#
 class CompositeReadIO
   # Create a new composite-read IO from the arguments, all of which should
   # respond to #read in a manner consistent with IO.
@@ -66,9 +66,9 @@ class UploadIO
   #     UploadIO.new("file.txt", "text/plain")
   #     UploadIO.new(file_io, "text/plain", "file.txt")
   #
-  attr_reader :content_type, :original_filename, :local_path, :io
+  attr_reader :content_type, :original_filename, :local_path, :io, :opts
 
-  def initialize(filename_or_io, content_type, filename = nil)
+  def initialize(filename_or_io, content_type, filename = nil, opts = {})
     io = filename_or_io
     local_path = ""
     if io.respond_to? :read
@@ -85,6 +85,7 @@ class UploadIO
     @original_filename = File.basename(filename)
     @local_path = local_path
     @io = io
+    @opts = opts
   end
 
   def self.convert!(io, content_type, original_filename, local_path)

--- a/lib/multipartable.rb
+++ b/lib/multipartable.rb
@@ -6,7 +6,8 @@ require 'parts'
       parts = params.map {|k,v| Parts::Part.new(boundary, k, v)}
       parts << Parts::EpiloguePart.new(boundary)
       ios = parts.map{|p| p.to_io }
-      self.set_content_type("multipart/form-data", { "boundary" => boundary })
+      self.set_content_type(headers["Content-Type"] || "multipart/form-data",
+                            { "boundary" => boundary })
       self.content_length = parts.inject(0) {|sum,i| sum + i.length }
       self.body_stream = CompositeReadIO.new(*ios)
     end


### PR DESCRIPTION
Hi,

made these changes to better support [SOAP-Attachments](http://www.w3.org/TR/SOAP-attachments), 
the default behaviour is preserved but allow for overriding the defaults:

Changes to allow for header specifications on the parts and the entire post. Basically, allow:
- the post content-type to be something else than 'form-data' (default remains multipart/form-data)
- the content-transfer-encoding to be something other than 'binary' for a part. Needed base64 encoding for a part.
- the content-disposition can now be an attachment, not just 'form-data' (part specific)
- set the content-id for a part (only if provided by an optional options hash)

this required extending the UploadIO#initialize to have an options hash as final argument. This
is where the various content specific stuff for a part can now be defined.
