### PR TITLE
Length of multi-byte string computed incorrectly.

### DIFF
--- a/lib/parts.rb
+++ b/lib/parts.rb
@@ -24,6 +24,10 @@ module Parts
       @io = StringIO.new(@part)
     end
 
+    def length
+     @part.bytesize
+    end 
+
     def build_part(boundary, name, value)
       part = ''
       part << "--#{boundary}\r\n"


### PR DESCRIPTION
Effects any foreign language character string, will end up reporting a overall content-length that is shorter than what is actually being sent.
