### PR TITLE
Allow CompositeIO objects to be rewound and read again

### DIFF
--- a/lib/composite_io.rb
+++ b/lib/composite_io.rb
@@ -24,12 +24,13 @@ class CompositeReadIO
     buffer = buf || ''
     done = if amount; nil; else ''; end
     partial_amount = amount
+    parts = @ios.dup
 
     loop do
       result = done
 
-      while !@ios.empty? && (result = @ios.first.read(partial_amount)) == done
-        @ios.shift
+      while !parts.empty? && (result = parts.first.read(partial_amount)) == done
+        parts.shift
       end
 
       result.force_encoding("BINARY") if result.respond_to?(:force_encoding)
@@ -45,6 +46,10 @@ class CompositeReadIO
     else
       done
     end
+  end
+  
+  def rewind
+    @ios.each { |io| io.rewind }
   end
 end
 

--- a/test/test_composite_io.rb
+++ b/test/test_composite_io.rb
@@ -56,6 +56,12 @@ class CompositeReadIOTest < Test::Unit::TestCase
     @io.read(32)
     assert_equal nil, @io.read(32)
   end
+  
+  def test_second_full_read_after_rewinding
+    @io.read
+    @io.rewind
+    assert_equal 'the quick brown fox', @io.read
+  end
 
   def test_convert_error
     assert_raises(ArgumentError) {


### PR DESCRIPTION
I ran into an issue writing a request middleware for Faraday, which uses this gem for it's file uploads.

My middleware constructs a HMAC signature and to do this, it needs to read the request body. Unfortunately, having read the CompositeIO to get this data, it is no longer in a readable state by the time the request is sent (as subsequent #read calls return an empty string).

Whilst this is consistent with normal IO objects, IO objects have a #rewind method that can reset the IO so it can be read again. This patch adds a #rewind method which I'm able to use my middleware to leave it readable for the rest of the middleware stack in Faraday.
