### PR TITLE
Add second, optional argument to UploadIO#respond_to? method signature

### DIFF
--- a/lib/composite_io.rb
+++ b/lib/composite_io.rb
@@ -102,7 +102,7 @@ class UploadIO
     @io.send(*args)
   end
 
-  def respond_to?(meth)
-    @io.respond_to?(meth) || super(meth)
+  def respond_to?(meth, include_all = false)
+    @io.respond_to?(meth, include_all) || super(meth, include_all)
   end
 end


### PR DESCRIPTION
This pull request changes the method signature for the `UploadIO#respond_to?` method to correctly include the second, optional argument. Unfortunately this omission was causing issues on Rubinius master, as reported by @craiglittle in the discussion for [this commit](https://github.com/rubinius/rubinius/commit/9fa7e49).

While this has since been fixed in Rubinius, it doesn't change the fact that the `respond_to?` method was being overridden incorrectly to begin with.
