### PR TITLE
Added handling of array-type parameters

### DIFF
--- a/lib/multipartable.rb
+++ b/lib/multipartable.rb
@@ -9,8 +9,17 @@ require 'parts'
     DEFAULT_BOUNDARY = "-----------RubyMultipartPost"
     def initialize(path, params, headers={}, boundary = DEFAULT_BOUNDARY)
       super(path, headers)
-      parts = params.map {|k,v| Parts::Part.new(boundary, k, v)}
-      parts << Parts::EpiloguePart.new(boundary)
+      parts = []
+	  params.map{|k,v|
+	    if v.kind_of?(Array)
+	      v.each{|item|
+	        parts << Parts::Part.new(boundary, k, item)
+	      }
+	    else
+	      parts << Parts::Part.new(boundary, k, v)
+	    end
+	  }
+	  parts << Parts::EpiloguePart.new(boundary)
       ios = parts.map{|p| p.to_io }
       self.set_content_type(headers["Content-Type"] || "multipart/form-data",
                             { "boundary" => boundary })

--- a/test/net/http/post/test_multipart.rb
+++ b/test/net/http/post/test_multipart.rb
@@ -40,6 +40,13 @@ class Net::HTTP::Post::MultiPartTest < Test::Unit::TestCase
     assert_results Net::HTTP::Post::Multipart.new("/foo/bar", :foo => 'bar', :file => @io)
   end
 
+  def test_form_multipart_body_with_arrayparam
+    File.open(TEMP_FILE, "w") {|f| f << "1234567890"}
+    @io = File.open(TEMP_FILE)
+    @io = UploadIO.new @io, "text/plain", TEMP_FILE
+    assert_results Net::HTTP::Post::Multipart.new("/foo/bar", :multivalueParam => ['bar','bah'], :file => @io)
+  end
+
   def assert_results(post)
     assert post.content_length && post.content_length > 0
     assert post.body_stream
@@ -52,5 +59,8 @@ class Net::HTTP::Post::MultiPartTest < Test::Unit::TestCase
     # ensure there is an epilogue
     assert body =~ /^--#{boundary_regex}--\r\n/
     assert body =~ /text\/plain/
+    if (body =~ /multivalueParam/)
+    	assert_equal 2, body.scan(/^.*multivalueParam.*$/).size
+    end
   end
 end


### PR DESCRIPTION
Added implementation and testcase for sending parameters with the same name [1].
If a form parameter is of type array each value is sent as separate part in POST/PUT requests.

[1] http://www.w3.org/TR/REC-html40/interact/forms.html#checkbox
