### PR TITLE
Fix overriding content-type header for FileParts

### DIFF
--- a/lib/parts.rb
+++ b/lib/parts.rb
@@ -62,9 +62,9 @@ module Parts
       @io = CompositeReadIO.new(StringIO.new(@head), io, StringIO.new(@foot))
     end
 
-    def build_head(boundary, name, filename, type, content_len, opts = {}, headers = {})
+    def build_head(boundary, name, filename, type, content_len, opts = {})
       opts = opts.clone
-      
+
       trans_encoding = opts.delete("Content-Transfer-Encoding") || "binary"
       content_disposition = opts.delete("Content-Disposition") || "form-data"
 
@@ -76,8 +76,8 @@ module Parts
         part << "Content-ID: #{content_id}\r\n"
       end
 
-      if headers["Content-Type"] != nil
-        part <<  "Content-Type: " + headers["Content-Type"] + "\r\n"
+      if opts["Content-Type"] != nil
+        part <<  "Content-Type: " + opts["Content-Type"] + "\r\n"
       else
         part << "Content-Type: #{type}\r\n"
       end

--- a/spec/parts_spec.rb
+++ b/spec/parts_spec.rb
@@ -1,16 +1,16 @@
 # Copyright, 2012, by Nick Sieger.
 # Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -41,7 +41,7 @@ RSpec.describe Parts do
       def content_type; 'application/data'; end
     end
   end
-  
+
   it "test_file_with_upload_io" do
     expect(Parts::Part.file?(UploadIO.new(__FILE__, "text/plain"))).to be true
   end
@@ -81,6 +81,11 @@ RSpec.describe Parts::FilePart do
     file = Tempfile.new(name.respond_to?(:force_encoding) ? name.force_encoding("UTF-8") : name)
     assert_part_length Parts::FilePart.new("boundary", "multibyte", UploadIO.new(file, "text/plain"))
     file.close
+  end
+
+   it "test_force_content_type_header" do
+    part = Parts::FilePart.new("boundary", "afile", UploadIO.new(TEMP_FILE, "text/plain"), { "Content-Type" => "application/pdf" })
+    expect(part.to_io.read).to match(/Content-Type: application\/pdf/)
   end
 end
 


### PR DESCRIPTION
It looks like the `headers` parameter in `build_head` is no longer used, and all headers are merged into `opts` hash. This PR removes the extraneous param and looks for Content-Type header in `opts` instead.
