### PR TITLE
Remove trailing line return

### DIFF
--- a/lib/parts.rb
+++ b/lib/parts.rb
@@ -89,7 +89,7 @@ module Parts
   class EpiloguePart
     include Part
     def initialize(boundary)
-      @part = "--#{boundary}--\r\n\r\n"
+      @part = "--#{boundary}--\r\n"
       @io = StringIO.new(@part)
     end
   end


### PR DESCRIPTION
While the epilogue should be ignored (see https://tools.ietf.org/html/rfc2046), it is validated by
[ModSecurity](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual#MULTIPART_STRICT_ERROR) which some sites have enabled.

See #40.

/cc @ioquatix 