### PR TITLE
CI: Allow Bundler 2, expand matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,19 @@
 language: ruby
-sudo: false
+
 dist: trusty
 cache: bundler
+
 rvm:
   - 2.0
   - 2.1
   - 2.2
   - 2.3
   - 2.4
+  - 2.5
+  - 2.6
   - ruby-head
   - jruby-head
+
 matrix:
   allow_failures:
     - rvm: "ruby-head"

--- a/multipart-post.gemspec
+++ b/multipart-post.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.rdoc_options = ["--main", "README.md", "-SHN", "-f", "darkfish"]
   spec.require_paths = ["lib"]
   
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler', ['>= 1.3', '< 3']
   spec.add_development_dependency 'rspec', '~> 3.4'
   spec.add_development_dependency 'rake'
 end


### PR DESCRIPTION
This PR adds more Rubies to the build matrix, and allows Bundler 2 in the development dependencies.

Also: drop `sudo: false` directive, which now does nothing.

🍏 This made the build pass.