### PR TITLE
Use Yard Docs

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,6 @@
+--no-private
+lib/**/.rb
+-
+History.txt
+LICENSE
+README.md

--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,8 @@
+<!--
+# @markup rdoc
+# @title CHANGELOG
+-->
+
 === 2.0.0 / 2013-12-21
 
 - Drop Ruby 1.8 compatibility
@@ -57,4 +62,3 @@
 * 1 major enhancement
 
   * Birthday!
-

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ methods besides `POST`.
 ## Features/Problems
 
 * Appears to actually work. A good feature to have.
-* Encapsulates posting of file/binary parts and name/value parameter parts, similar to 
+* Encapsulates posting of file/binary parts and name/value parameter parts, similar to
   most browsers' file upload forms.
 * Provides an `UploadIO` helper class to prepare IO objects for inclusion in the params
   hash of the multipart post object.
 
 ## Installation
 
-    gem install multipart-post 
-    
+    gem install multipart-post
+
 or in your Gemfile
 
     gem 'multipart-post'
@@ -51,7 +51,7 @@ res = Net::HTTP.start(url.host, url.port) do |http|
 end
 ```
 
-To post files with other normal, non-file params such as input values, you need to pass hashes to the `Multipart.new` method. 
+To post files with other normal, non-file params such as input values, you need to pass hashes to the `Multipart.new` method.
 
 In Rails 4 for example:
 

--- a/lib/composite_io.rb
+++ b/lib/composite_io.rb
@@ -7,11 +7,11 @@
 # Concatenate together multiple IO objects into a single, composite IO object
 # for purposes of reading as a single stream.
 #
-# Usage:
-#
-#     crio = CompositeReadIO.new(StringIO.new('one'), StringIO.new('two'), StringIO.new('three'))
+# @example
+#     crio = CompositeReadIO.new(StringIO.new('one'),
+#                                StringIO.new('two'),
+#                                StringIO.new('three'))
 #     puts crio.read # => "onetwothree"
-#
 class CompositeReadIO
   # Create a new composite-read IO from the arguments, all of which should
   # respond to #read in a manner consistent with IO.
@@ -56,6 +56,8 @@ end
 
 # Convenience methods for dealing with files and IO that are to be uploaded.
 class UploadIO
+  attr_reader :content_type, :original_filename, :local_path, :io, :opts
+
   # Create an upload IO suitable for including in the params hash of a
   # Net::HTTP::Post::Multipart.
   #
@@ -67,13 +69,9 @@ class UploadIO
   # uploading directly from a form in a framework, which often save the file to
   # an arbitrarily named RackMultipart file in /tmp).
   #
-  # Usage:
-  #
+  # @example
   #     UploadIO.new("file.txt", "text/plain")
   #     UploadIO.new(file_io, "text/plain", "file.txt")
-  #
-  attr_reader :content_type, :original_filename, :local_path, :io, :opts
-
   def initialize(filename_or_io, content_type, filename = nil, opts = {})
     io = filename_or_io
     local_path = ""
@@ -95,7 +93,9 @@ class UploadIO
   end
 
   def self.convert!(io, content_type, original_filename, local_path)
-    raise ArgumentError, "convert! has been removed. You must now wrap IOs using:\nUploadIO.new(filename_or_io, content_type, filename=nil)\nPlease update your code."
+    raise ArgumentError, "convert! has been removed. You must now wrap IOs " \
+                         "using:\nUploadIO.new(filename_or_io, content_type, " \
+                         "filename=nil)\nPlease update your code."
   end
 
   def method_missing(*args)

--- a/lib/multipartable.rb
+++ b/lib/multipartable.rb
@@ -5,25 +5,27 @@
 #++
 
 require 'parts'
-  module Multipartable
-    DEFAULT_BOUNDARY = "-----------RubyMultipartPost"
-    def initialize(path, params, headers={}, boundary = DEFAULT_BOUNDARY)
-      headers = headers.clone # don't want to modify the original variable
-      parts_headers = headers.delete(:parts) || {}
-      super(path, headers)
-      parts = params.map do |k,v|
-        case v
-        when Array
-          v.map {|item| Parts::Part.new(boundary, k, item, parts_headers[k]) }
-        else
-          Parts::Part.new(boundary, k, v, parts_headers[k])
-        end
-      end.flatten
-      parts << Parts::EpiloguePart.new(boundary)
-      ios = parts.map {|p| p.to_io }
-      self.set_content_type(headers["Content-Type"] || "multipart/form-data",
-                            { "boundary" => boundary })
-      self.content_length = parts.inject(0) {|sum,i| sum + i.length }
-      self.body_stream = CompositeReadIO.new(*ios)
-    end
+
+module Multipartable
+  DEFAULT_BOUNDARY = "-----------RubyMultipartPost"
+
+  def initialize(path, params, headers={}, boundary = DEFAULT_BOUNDARY)
+    headers = headers.clone # don't want to modify the original variable
+    parts_headers = headers.delete(:parts) || {}
+    super(path, headers)
+    parts = params.map do |k,v|
+      case v
+      when Array
+        v.map {|item| Parts::Part.new(boundary, k, item, parts_headers[k]) }
+      else
+        Parts::Part.new(boundary, k, v, parts_headers[k])
+      end
+    end.flatten
+    parts << Parts::EpiloguePart.new(boundary)
+    ios = parts.map {|p| p.to_io }
+    self.set_content_type(headers["Content-Type"] || "multipart/form-data",
+                          { "boundary" => boundary })
+    self.content_length = parts.inject(0) {|sum,i| sum + i.length }
+    self.body_stream = CompositeReadIO.new(*ios)
   end
+end

--- a/lib/net/http/post/multipart.rb
+++ b/lib/net/http/post/multipart.rb
@@ -11,14 +11,15 @@ require 'composite_io'
 require 'multipartable'
 require 'parts'
 
-module Net #:nodoc:
-  class HTTP #:nodoc:
+module Net
+  class HTTP
     class Put
       class Multipart < Put
         include Multipartable
       end
     end
-    class Post #:nodoc:
+
+    class Post
       class Multipart < Post
         include Multipartable
       end

--- a/lib/parts.rb
+++ b/lib/parts.rb
@@ -5,7 +5,7 @@
 #++
 
 module Parts
-  module Part #:nodoc:
+  module Part
     def self.new(boundary, name, value, headers = {})
       headers ||= {} # avoid nil values
       if file?(value)
@@ -28,8 +28,14 @@ module Parts
     end
   end
 
+  # Represents a parametric part to be filled with given value.
   class ParamPart
     include Part
+
+    # @param boundary [String]
+    # @param name [#to_s]
+    # @param value [String]
+    # @param headers [Hash] Content-Type is used, if present.
     def initialize(boundary, name, value, headers = {})
       @part = build_part(boundary, name, value, headers)
       @io = StringIO.new(@part)
@@ -39,6 +45,10 @@ module Parts
      @part.bytesize
     end
 
+    # @param boundary [String]
+    # @param name [#to_s]
+    # @param value [String]
+    # @param headers [Hash] Content-Type is used, if present.
     def build_part(boundary, name, value, headers = {})
       part = ''
       part << "--#{boundary}\r\n"
@@ -52,7 +62,13 @@ module Parts
   # Represents a part to be filled from file IO.
   class FilePart
     include Part
+
     attr_reader :length
+
+    # @param boundary [String]
+    # @param name [#to_s]
+    # @param io [IO]
+    # @param headers [Hash]
     def initialize(boundary, name, io, headers = {})
       file_length = io.respond_to?(:length) ?  io.length : File.size(io.local_path)
       @head = build_head(boundary, name, io.original_filename, io.content_type, file_length,
@@ -62,6 +78,12 @@ module Parts
       @io = CompositeReadIO.new(StringIO.new(@head), io, StringIO.new(@foot))
     end
 
+    # @param boundary [String]
+    # @param name [#to_s]
+    # @param filename [String]
+    # @param type [String]
+    # @param content_len [Integer]
+    # @param opts [Hash]
     def build_head(boundary, name, filename, type, content_len, opts = {})
       opts = opts.clone
 
@@ -95,6 +117,7 @@ module Parts
   # Represents the epilogue or closing boundary.
   class EpiloguePart
     include Part
+
     def initialize(boundary)
       @part = "--#{boundary}--\r\n"
       @io = StringIO.new(@part)

--- a/multipart-post.gemspec
+++ b/multipart-post.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split("\n")
   spec.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   spec.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  spec.rdoc_options = ["--main", "README.md", "-SHN", "-f", "darkfish"]
   spec.require_paths = ["lib"]
   
   spec.add_development_dependency 'bundler', ['>= 1.3', '< 3']


### PR DESCRIPTION
  - remove default RDoc args - this broke builds for people on RPM-built thing #44 - they didn't have Darkfish pre-installed and things broke
  - add some whitespace
  - break some long lines

## Details about YARD

- more explicit
- has no `:nodoc:` ([for reasons](https://github.com/lsegal/yard/issues/11))
- it's Markdown, GFH (GitHub-flavored)
- supports having a configuration file checked in (see below)

### Generated docs online

The main place people go for gem docs is the dynamically default-configured generated ones at https://www.rubydoc.info

Here's this gem, rendered: https://www.rubydoc.info/gems/multipart-post  

On rubydoc.info: I believe these are regenerated on new versions of the gem becoming available) 

rubydoc.info will probably not respect any locally-configured settings files. To gain most benefit, keep the defaults.

