### PR TITLE
YARD: include files in glob pattern

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,5 +1,5 @@
 --no-private
-lib/**/.rb
+lib/**/*.rb
 -
 History.txt
 LICENSE


### PR DESCRIPTION
This is a bugfix to the documentation generation.

The PR **fixes** the YARD **glob pattern** to locate Ruby project files.

I took a look at what rubydoc.info would have rendered, and found that there were 0 files matched, apart from the named Files (README, etc).

## Before

What it looks like before this change:

https://www.rubydoc.info/github/nicksieger/multipart-post/master/

## After

With this change, ~I hope there will be~ there are more classes and methods to read about:

https://www.rubydoc.info/github/olleolleolle/multipart-post/e4c447